### PR TITLE
[fix] fixed container overflow when only one server is defined

### DIFF
--- a/conf/tester.conf
+++ b/conf/tester.conf
@@ -20,5 +20,3 @@ server
 		index: youpi.bad_extension
 		cgi_extension: .bla
 		cgi_path: test/cgi_tester
-server
-	port: 8888

--- a/server/Config/Config.cpp
+++ b/server/Config/Config.cpp
@@ -82,7 +82,7 @@ ServerInfo Config::_parseServer(configIterator& it, const configIterator& end) {
     } else if (_identifier == "server_name") {
       _server_info.serverName = _value.str();
     } else if (_identifier == "location") {
-      _server_info.locations[_value.str()] = _parseLocation(++it, _server_info, _value.str());
+      _server_info.locations[_value.str()] = _parseLocation(++it, end, _server_info, _value.str());
       continue;
     } else {
       std::cout << "ERROR: invalid config file" << std::endl;
@@ -97,10 +97,10 @@ ServerInfo Config::_parseServer(configIterator& it, const configIterator& end) {
   return _server_info;
 }
 
-LocationInfo Config::_parseLocation(configIterator& it, const ServerInfo& serverInfo, const std::string& id) {
+LocationInfo Config::_parseLocation(configIterator& it, const configIterator& end, const ServerInfo& serverInfo, const std::string& id) {
   LocationInfo _location_info = _init_locationInfo(serverInfo);
   _location_info.id           = id;
-  while (*it != "\n") {
+  while (it != end && *it != "\n" && *it != "server") {
     std::pair<int, std::string> _trimmed = _trimLeftTab(*it);
     if (_trimmed.first != 2) {
       break;

--- a/server/Config/Config.hpp
+++ b/server/Config/Config.hpp
@@ -6,7 +6,7 @@
 /*   By: jaemjung <jaemjung@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/18 18:06:58 by jaemjung          #+#    #+#             */
-/*   Updated: 2022/08/31 23:20:58 by jaemjung         ###   ########.fr       */
+/*   Updated: 2022/09/04 14:22:00 by jaemjung         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,7 +75,8 @@ class Config {
   void         _printConfigContent();
   void         _startParse();
   ServerInfo   _parseServer(configIterator& it, const configIterator& end);
-  LocationInfo _parseLocation(configIterator& it, const ServerInfo& serverInfo, const std::string& id);
+  LocationInfo _parseLocation(configIterator& it, const configIterator& end, const ServerInfo& serverInfo,
+                              const std::string& id);
   void         _parseLocationInfoToken(LocationInfo& info, const std::string& identifier, const std::string& value);
   void         _parseDefaultErrorPage(const std::string& pages, std::map<int, std::string>& defaultErrorPages);
   std::vector<std::string>    _parseAllowedMethod(const std::string& value);


### PR DESCRIPTION
Location info를 파싱하는 중에 vector의 iterator가 end까지 갔는지 체크해주지 않아 벌어졌던 문제였읍니다,,,
해당 문제를 수정하였습니다.
확인 후 바로 머지 하시면 됩니다!