### PR TITLE
[feat] some config error handling added

### DIFF
--- a/conf/err_wrong_indent.conf
+++ b/conf/err_wrong_indent.conf
@@ -1,0 +1,21 @@
+server
+	port: 7777
+	server_name: tester
+	host: 123.123.123.122
+	root: test
+	location: /
+		allowed_method: GET
+		cgi_extension: .bla
+		cgi_path: test/cgi_tester
+	location: /put_test
+		allowed_method: PUT
+		root: test/put_test
+	location: /post_body
+		allowed_method: POST
+		client_max_body_size: 100
+	location: /directory
+		allowed_method: GET POST
+		root: test/YoupiBanane
+		index: youpi.bad_extension
+		cgi_extension: .bla
+		cgi_path: test/cgi_tester

--- a/conf/err_wrong_ip.conf
+++ b/conf/err_wrong_ip.conf
@@ -1,0 +1,21 @@
+server
+	port: 7777
+	server_name: tester
+	host: 255.255.255.256
+	root: test
+	location: /
+		allowed_method: GET
+		cgi_extension: .bla
+		cgi_path: test/cgi_tester
+	location: /put_test
+		allowed_method: PUT
+		root: test/put_test
+	location: /post_body
+		allowed_method: POST
+		client_max_body_size: 100
+	location: /directory
+		allowed_method: GET POST
+		root: test/YoupiBanane
+		index: youpi.bad_extension
+		cgi_extension: .bla
+		cgi_path: test/cgi_tester

--- a/conf/err_wrong_port.conf
+++ b/conf/err_wrong_port.conf
@@ -1,0 +1,21 @@
+server
+	port: aswed
+	server_name: tester
+	host: 127.0.0.1
+	root: test
+	location: /
+		allowed_method: GET
+		cgi_extension: .bla
+		cgi_path: test/cgi_tester
+	location: /put_test
+		allowed_method: PUT
+		root: test/put_test
+	location: /post_body
+		allowed_method: POST
+		client_max_body_size: 100
+	location: /directory
+		allowed_method: GET POST
+		root: test/YoupiBanane
+		index: youpi.bad_extension
+		cgi_extension: .bla
+		cgi_path: test/cgi_tester

--- a/server/Config/Config.cpp
+++ b/server/Config/Config.cpp
@@ -21,8 +21,7 @@ void Config::_readConfigFile(const std::string& confFile) {
       _configContent.push_back(_buffer);
     }
   } else {
-    std::cout << "ERROR: cannot open " << confFile << std::endl;
-    std::exit(1);
+    _error(LOG_LOCATION, "Error: Failed to open config file");
   }
 }
 
@@ -39,9 +38,7 @@ void Config::_startParse() {
       ServerInfo serverInfo = _parseServer(++it, _configContent.end());
       _serverInfos.push_back(serverInfo);
     } else {
-      std::cout << "ERROR: invalid config file" << std::endl;
-      Log::log()(LOG_LOCATION, "ERROR: invalid config file", ALL);
-      std::exit(1);
+      _error(LOG_LOCATION, "Error: Invalid config file");
     }
   }
   if (_serverInfos.empty()) {
@@ -75,10 +72,16 @@ ServerInfo Config::_parseServer(configIterator& it, const configIterator& end) {
     } else if (_identifier == "default_error_page") {
       _parseDefaultErrorPage(_value.str(), _server_info.defaultErrorPages);
     } else if (_identifier == "host") {
-      inet_aton(_value.str().c_str(), &_server_info.hostIp);  // TODO: ip 주소 잘못됐을 때 에러처리
+      inet_aton(_value.str().c_str(), &_server_info.hostIp);
+      if (_server_info.hostIp.s_addr == INADDR_NONE || _server_info.hostIp.s_addr == INADDR_ANY) {
+        _error(LOG_LOCATION, "Error: Invalid host ip");
+      }
     } else if (_identifier == "port") {
       _value >> vi;
-      _server_info.hostPort = vi;  // TODO: 포트넘버 범위 벗어나거나 잘못됐을 때 에러처리
+      if (vi < 1 || vi > PORT_MAX) {
+        _error(LOG_LOCATION, "Error: Invalid port number");
+      }
+      _server_info.hostPort = vi;
     } else if (_identifier == "server_name") {
       _server_info.serverName = _value.str();
     } else if (_identifier == "location") {
@@ -97,7 +100,8 @@ ServerInfo Config::_parseServer(configIterator& it, const configIterator& end) {
   return _server_info;
 }
 
-LocationInfo Config::_parseLocation(configIterator& it, const configIterator& end, const ServerInfo& serverInfo, const std::string& id) {
+LocationInfo Config::_parseLocation(configIterator& it, const configIterator& end, const ServerInfo& serverInfo,
+                                    const std::string& id) {
   LocationInfo _location_info = _init_locationInfo(serverInfo);
   _location_info.id           = id;
   while (it != end && *it != "\n" && *it != "server") {
@@ -360,6 +364,11 @@ std::string Config::_itoa(int i) {
   std::stringstream ss;
   ss << i;
   return ss.str();
+}
+
+void Config::_error(const char* file, int line, const char* function, std::string message) {
+  Log::log()(file, line, function, message, ALL);
+  exit(1);
 }
 
 int Config::_error_codes[ERROR_PAGES_COUNT] = {400, 402, 404, 405, 413, 500, 501, 502, 503, 504, 505};

--- a/server/Config/Config.hpp
+++ b/server/Config/Config.hpp
@@ -1,15 +1,3 @@
-/* ************************************************************************** */
-/*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   Config.hpp                                         :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: jaemjung <jaemjung@student.42seoul.kr>     +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/08/18 18:06:58 by jaemjung          #+#    #+#             */
-/*   Updated: 2022/09/04 14:22:00 by jaemjung         ###   ########.fr       */
-/*                                                                            */
-/* ************************************************************************** */
-
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
@@ -25,8 +13,9 @@
 
 #define ERROR_PAGES_COUNT 11
 #define ERROR_PAGES_PATH "/error_pages/"
-#define HTTP_DEFAULT_PORT 80
+#define HTTP_DEFAULT_PORT 4242
 #define DEFAULT_MAX_BODY_SIZE 200000000
+#define PORT_MAX 65535
 
 struct LocationInfo {
   std::string                id;                 // default "/"
@@ -93,6 +82,7 @@ class Config {
   void                        _parsedConfigResult();
   void                        _setPorts();
   std::string                 _itoa(int i);
+  void                        _error(const char* file, int line, const char* function, std::string message);
 
   // Constructor
  public:

--- a/server/HttpRequest/HttpRequest.hpp
+++ b/server/HttpRequest/HttpRequest.hpp
@@ -8,7 +8,7 @@
 #include "RequestStorage.hpp"
 
 #define HTTP_PARSING_TIME_OUT 10
-#define HTTP_DEFAULT_PORT 80
+#define HTTP_DEFAULT_PORT 4242
 #define HTTP_MAX_HEADER_SIZE 8192
 
 enum HttpRequestParsingState {


### PR DESCRIPTION
Config 객체 생성 시 ip, port 번호가 잘못 입력되는 경우의 에러처리를 추가하였습니다.

기본 port의 값이 80에서 4242로 변경되었습니다.

또한 Router에서 이미 열려있는 포트에 대해 포트를 생성하려고 할 경우 sig abort 오류가 터지는데 한번 확인해줘야할듯?합니다.
